### PR TITLE
Remove json from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pythonwhois
 wafw00f
 sslyze
 beautifulsoup4
-json


### PR DESCRIPTION
JSON is automatically installed in python; pip will not allow an install of json.