### PR TITLE
Add AI analysis background task

### DIFF
--- a/opf-db/Cargo.toml
+++ b/opf-db/Cargo.toml
@@ -17,3 +17,4 @@ chrono = "0.4.24"
 rand = "0.8.5"
 petgraph = "0.6.3"
 itertools = "0.10.5"
+llm = { version = "1.2.3", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "api"] }

--- a/opf-db/src/lib.rs
+++ b/opf-db/src/lib.rs
@@ -6,10 +6,14 @@ use log::info;
 use rand::{distributions::Alphanumeric, Rng};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::RwLock;
+use tokio::time;
 
 use opf_models::event::Event::{ResponseError, ResponseSimple};
 use opf_models::event::{send_event_to, Domain, Event};
-use opf_models::{KeyStore, Workspace};
+use opf_models::{KeyStore, Workspace, Suggestion};
+
+use llm::{builder::{LLMBackend, LLMBuilder}, chat::ChatMessage};
+use serde::Deserialize;
 
 use crate::store::DB;
 
@@ -21,6 +25,7 @@ mod store_link;
 mod store_module;
 mod store_target;
 mod store_workspace;
+mod store_suggestion;
 
 #[derive(Debug)]
 pub struct DBStore {
@@ -83,8 +88,12 @@ pub async fn new(node_tx: UnboundedSender<(Domain, Event)>) -> (UnboundedSender<
 impl DBStore {
     pub async fn launch(mut self) {
         info!("running database controller...");
+        let mut ai_interval = time::interval(std::time::Duration::from_secs(60));
         loop {
             tokio::select! {
+                _ = ai_interval.tick() => {
+                    self.ai_analyze().await;
+                },
                 Some(event) = self.self_rx.recv() => {
                     let db = match self.dbs.get_mut(&self.current_workspace) {
                         Some(db) => db,
@@ -144,6 +153,11 @@ impl DBStore {
                                 let _ = send_event_to(&self.node_tx, (Domain::CLI, ResponseError(e.to_string()))).await;
                             }
                         }
+                        Event::CommandSuggestion(command) => {
+                            if let Err(e) = db.on_suggestion_command(command).await {
+                                let _ = send_event_to(&self.node_tx, (Domain::CLI, ResponseError(e.to_string()))).await;
+                            }
+                        }
                         Event::LoadKeystore(keystore) => self.load_keystore(keystore).await,
                         _ => {
                             if let Err(e) = send_event_to(&self.node_tx, (Domain::CLI, event)).await {
@@ -158,5 +172,63 @@ impl DBStore {
 
     pub async fn load_keystore(&mut self, keystore: KeyStore) {
         self.keystore = Arc::new(RwLock::new(keystore));
+    }
+
+    async fn ai_analyze(&self) {
+        let db = match self.dbs.get(&self.current_workspace) {
+            Some(db) => db,
+            None => return,
+        };
+
+        let targets = db.targets.read().await;
+        if targets.is_empty() {
+            return;
+        }
+
+        let mut content = String::new();
+        for (_, target) in targets.iter() {
+            content.push_str(&format!(
+                "id={} type={} name={} meta={:?}\n",
+                target.target_id, target.target_type, target.target_name, target.meta
+            ));
+        }
+
+        let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+        let llm = LLMBuilder::new()
+            .backend(LLMBackend::OpenAI)
+            .api_key(api_key)
+            .model("gpt-3.5-turbo")
+            .max_tokens(512)
+            .temperature(0.7)
+            .stream(false)
+            .build()
+            .expect("Failed to build LLM (OpenAI)");
+
+        let messages = vec![
+            ChatMessage::user()
+                .content(format!(
+                    "Analyze these targets and propose commands to improve the dataset. \
+Return only JSON array of objects {{\"description\":string,\"command\":string}}.\n{}",
+                    content
+                ))
+                .build(),
+        ];
+
+        #[derive(Deserialize)]
+        struct LlmSuggestion { description: String, command: String }
+
+        if let Ok(text) = llm.chat(&messages).await {
+            if let Ok(list) = serde_json::from_str::<Vec<LlmSuggestion>>(&text) {
+                let mut suggestions = db.suggestions.write().await;
+                for item in list {
+                    let id = (suggestions.len() + 1) as i32;
+                    suggestions.insert(
+                        id,
+                        Suggestion { suggestion_id: id, description: item.description, command: item.command },
+                    );
+                }
+                let _ = send_event_to(&self.node_tx, (Domain::CLI, Event::ResponseSimple("ai suggestions updated".into()))).await;
+            }
+        }
     }
 }

--- a/opf-db/src/store.rs
+++ b/opf-db/src/store.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::RwLock;
 
 use opf_models::event::Event;
-use opf_models::{Group, Link, Target};
+use opf_models::{Group, Link, Target, Suggestion};
 
 #[derive(Debug)]
 pub struct DB {
@@ -13,6 +13,7 @@ pub struct DB {
     pub targets: RwLock<HashMap<i32, Target>>,
     pub groups: RwLock<HashMap<i32, Group>>,
     pub links: RwLock<HashMap<i32, Link>>,
+    pub suggestions: RwLock<HashMap<i32, Suggestion>>,
 }
 
 impl DB {
@@ -23,6 +24,7 @@ impl DB {
             targets: RwLock::new(HashMap::new()),
             groups: RwLock::new(HashMap::new()),
             links: RwLock::new(HashMap::new()),
+            suggestions: RwLock::new(HashMap::new()),
         }
     }
 }

--- a/opf-db/src/store_suggestion.rs
+++ b/opf-db/src/store_suggestion.rs
@@ -1,0 +1,60 @@
+use opf_models::event::{send_event, Event};
+use opf_models::{self, error::ErrorKind, suggestion, Command, CommandAction, Suggestion};
+
+use crate::store::DB;
+
+impl DB {
+    pub async fn on_suggestion_command(&mut self, command: Command) -> Result<(), ErrorKind> {
+        match command.action {
+            CommandAction::List => self.list_suggestions().await,
+            CommandAction::Accept => self.approve_suggestion(command).await,
+            CommandAction::Del => self.deny_suggestion(command).await,
+            _ => Err(ErrorKind::ActionNotAvailable),
+        }
+    }
+
+    async fn list_suggestions(&self) -> Result<(), ErrorKind> {
+        let suggestions = self.suggestions.read().await;
+        let mut headers = vec![
+            suggestion::ID.to_string(),
+            suggestion::DESCRIPTION.to_string(),
+            suggestion::COMMAND.to_string(),
+        ];
+        let mut rows = vec![];
+        for (_, sugg) in suggestions.iter() {
+            rows.push(vec![
+                sugg.suggestion_id.to_string(),
+                sugg.description.clone(),
+                sugg.command.clone(),
+            ]);
+        }
+        send_event(&self.db_tx, Event::ResponseTable((headers, rows))).await
+    }
+
+    async fn approve_suggestion(&mut self, command: Command) -> Result<(), ErrorKind> {
+        let suggestion_id = command
+            .params
+            .get(suggestion::ID)
+            .ok_or(ErrorKind::InvalidFormatArgument)?
+            .parse::<i32>()
+            .map_err(|_| ErrorKind::InvalidFormatArgument)?;
+        let mut suggestions = self.suggestions.write().await;
+        let sugg = suggestions
+            .remove(&suggestion_id)
+            .ok_or(ErrorKind::GenericError(format!("suggestion {} not found", suggestion_id)))?;
+        send_event(&self.db_tx, Event::ResponseSimple(format!("suggestion {} executed", suggestion_id))).await?;
+        send_event(&self.db_tx, Event::NewCommand(sugg.command)).await
+    }
+
+    async fn deny_suggestion(&mut self, command: Command) -> Result<(), ErrorKind> {
+        let suggestion_id = command
+            .params
+            .get(suggestion::ID)
+            .ok_or(ErrorKind::InvalidFormatArgument)?
+            .parse::<i32>()
+            .map_err(|_| ErrorKind::InvalidFormatArgument)?;
+        let mut suggestions = self.suggestions.write().await;
+        suggestions.remove(&suggestion_id);
+        send_event(&self.db_tx, Event::ResponseSimple(format!("suggestion {} denied", suggestion_id))).await
+    }
+}

--- a/opf-models/src/event.rs
+++ b/opf-models/src/event.rs
@@ -17,6 +17,7 @@ pub enum Event {
     CommandKeystore(Command),
     CommandExport(Command),
     CommandGroup(Command),
+    CommandSuggestion(Command),
     // Module variant
     PrepareModule((String, Command)),
     ExecuteModule((i32, Target, String, HashMap<String, String>)),

--- a/opf-models/src/lib.rs
+++ b/opf-models/src/lib.rs
@@ -20,6 +20,7 @@ pub mod link;
 pub mod metadata;
 pub mod module;
 pub mod port;
+pub mod suggestion;
 pub mod target;
 pub mod workspace;
 
@@ -61,6 +62,7 @@ pub enum CommandObject {
     Api,
     Workspace,
     Keystore,
+    Suggestion,
     Export(String),
     Module(String),
 }
@@ -72,6 +74,13 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyStore(pub HashMap<String, String>);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Suggestion {
+    pub suggestion_id: i32,
+    pub description: String,
+    pub command: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Target {

--- a/opf-models/src/suggestion.rs
+++ b/opf-models/src/suggestion.rs
@@ -1,0 +1,3 @@
+pub const ID: &str = "id";
+pub const DESCRIPTION: &str = "description";
+pub const COMMAND: &str = "command";

--- a/opf-node/src/lib.rs
+++ b/opf-node/src/lib.rs
@@ -103,6 +103,9 @@ impl Node {
                 CommandObject::Keystore => {
                     send_event(&self.db_tx, Event::CommandKeystore(command)).await
                 }
+                CommandObject::Suggestion => {
+                    send_event(&self.db_tx, Event::CommandSuggestion(command)).await
+                }
                 CommandObject::Link => send_event(&self.db_tx, Event::CommandLink(command)).await,
                 CommandObject::None => match command.action {
                     CommandAction::Help => self.on_help().await,


### PR DESCRIPTION
## Summary
- integrate `llm` crate for OpenAI access
- add structured suggestions with approve/deny flow
- background analysis stores JSON suggestions in DB

## Testing
- `cargo check` *(fails: Could not connect to server)*