### PR TITLE
Add AI analysis background task

### DIFF
--- a/opf-db/Cargo.toml
+++ b/opf-db/Cargo.toml
@@ -17,3 +17,5 @@ chrono = "0.4.24"
 rand = "0.8.5"
 petgraph = "0.6.3"
 itertools = "0.10.5"
+serde_json = "1.0"
+llm = { version = "1.2.3", features = ["openai", "anthropic", "ollama", "deepseek", "xai", "phind", "google", "groq", "api"] }

--- a/opf-db/src/lib.rs
+++ b/opf-db/src/lib.rs
@@ -6,10 +6,15 @@ use log::info;
 use rand::{distributions::Alphanumeric, Rng};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::RwLock;
+use tokio::time;
 
 use opf_models::event::Event::{ResponseError, ResponseSimple};
 use opf_models::event::{send_event_to, Domain, Event};
 use opf_models::{KeyStore, Workspace};
+
+use llm::{builder::{LLMBackend, LLMBuilder}, chat::ChatMessage};
+use serde::Deserialize;
+use serde_json;
 
 use crate::store::DB;
 
@@ -21,6 +26,12 @@ mod store_link;
 mod store_module;
 mod store_target;
 mod store_workspace;
+
+#[derive(Debug, Deserialize)]
+struct LlmSuggestion {
+    description: String,
+    command: String,
+}
 
 #[derive(Debug)]
 pub struct DBStore {
@@ -83,8 +94,12 @@ pub async fn new(node_tx: UnboundedSender<(Domain, Event)>) -> (UnboundedSender<
 impl DBStore {
     pub async fn launch(mut self) {
         info!("running database controller...");
+        let mut ai_interval = time::interval(std::time::Duration::from_secs(60));
         loop {
             tokio::select! {
+                _ = ai_interval.tick() => {
+                    self.ai_analyze().await;
+                },
                 Some(event) = self.self_rx.recv() => {
                     let db = match self.dbs.get_mut(&self.current_workspace) {
                         Some(db) => db,
@@ -159,4 +174,51 @@ impl DBStore {
     pub async fn load_keystore(&mut self, keystore: KeyStore) {
         self.keystore = Arc::new(RwLock::new(keystore));
     }
+
+    async fn ai_analyze(&self) {
+        let db = match self.dbs.get(&self.current_workspace) {
+            Some(db) => db,
+            None => return,
+        };
+
+        let targets = db.targets.read().await;
+        if targets.is_empty() {
+            return;
+        }
+
+        let mut content = String::new();
+        for (_, target) in targets.iter() {
+            content.push_str(&format!("{}:{} ", target.target_type, target.target_name));
+        }
+
+        let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("sk-TESTKEY".into());
+        let llm = LLMBuilder::new()
+            .backend(LLMBackend::OpenAI)
+            .api_key(api_key)
+            .model("gpt-3.5-turbo")
+            .max_tokens(512)
+            .temperature(0.7)
+            .stream(false)
+            .build()
+            .expect("Failed to build LLM (OpenAI)");
+
+        let prompt = format!(
+            "Analyze and correlate these targets: {}. Return JSON in the form [{description: string, command: string}]",
+            content
+        );
+        let messages = vec![ChatMessage::user().content(prompt).build()];
+
+        if let Ok(text) = llm.chat(&messages).await {
+            if let Ok(list) = serde_json::from_str::<Vec<LlmSuggestion>>(&text) {
+                let mut output = String::new();
+                for (idx, item) in list.iter().enumerate() {
+                    output.push_str(&format!("{}: {} -> {}\n", idx + 1, item.description, item.command));
+                }
+                let _ = send_event_to(&self.node_tx, (Domain::CLI, Event::ResponseSimple(output))).await;
+            } else {
+                let _ = send_event_to(&self.node_tx, (Domain::CLI, Event::ResponseSimple(text))).await;
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- integrate `llm` crate for OpenAI access
- add periodic AI-based analysis of targets in DB controller
- parse LLM output as structured suggestions

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo check -q` *(fails: could not connect to crates.io)*